### PR TITLE
feat(user): implement User entity and UserRepository

### DIFF
--- a/src/main/java/com/universidad/proyecto/FindTrack/model/User.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/model/User.java
@@ -1,0 +1,47 @@
+package com.universidad.proyecto.FindTrack.model;
+
+
+import java.util.UUID;
+
+import org.hibernate.annotations.CurrentTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import lombok.*;
+
+
+@Entity
+@Table(name = "users")
+@lombok.Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, unique = true)
+    private UUID id;
+
+    @Email
+    @Column(name = "email", unique = true, nullable = false)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "currency", nullable = false)
+    private String currency = "MXN";
+
+    @Column(name = "created_at", nullable = false)
+    @CurrentTimestamp
+    private java.time.LocalDateTime createdAt;
+    
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/repository/UserRepository.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.universidad.proyecto.FindTrack.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.universidad.proyecto.FindTrack.model.User;
+
+
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Se implementa la entidad `User` mapeada con JPA hacia la tabla `users` en la base de datos, junto con su repositorio `UserRepository` para la gestión de acceso a datos.

Esto permite que la aplicación pueda interactuar correctamente con la tabla de usuarios mediante Spring Data JPA, incluyendo la búsqueda de usuarios por correo electrónico.

---

## Issue relacionado

Closes #3

---

## Cambios realizados

- **User.java**
  - Se creó la entidad JPA `User` con las anotaciones correspondientes (`@Entity`, `@Table`, `@Column`).
  - Se agregaron todos los atributos necesarios para que coincidan con la estructura de la tabla `users`.
  - Se definió `UUID` como tipo del campo `id`.
  - Se agregó `@CreationTimestamp` al campo `createdAt` para registrar automáticamente la fecha de creación.

- **UserRepository.java**
  - Se creó la interfaz `UserRepository` extendiendo `JpaRepository`.
  - Se añadió el método:
    `Optional<User> findByEmail(String email)`
    para permitir la búsqueda de usuarios por email.

---

## ¿Cómo probarlo?

1. Hacer pull desde la rama `develop`.
2. Ejecutar el proyecto con:

```bash
mvn spring-boot:run
```
Verificar que la aplicación inicia correctamente sin errores de mapeo JPA.
