### PR TITLE
feat(auth): implement register user

### DIFF
--- a/src/main/java/com/universidad/proyecto/FindTrack/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/config/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.universidad.proyecto.findtrack.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/config/WebSecurityConfig.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/config/WebSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.universidad.proyecto.findtrack.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> response
+                                .sendError(HttpServletResponse.SC_UNAUTHORIZED)))
+                .csrf(csrf -> csrf.disable());
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/controller/AuthController.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.universidad.proyecto.findtrack.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.universidad.proyecto.findtrack.service.AutnService;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import com.universidad.proyecto.findtrack.dto.request.RegisterRequestDTO;
+import com.universidad.proyecto.findtrack.dto.response.AuthResponseDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AutnService autnService;
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponseDTO> register(@Valid @RequestBody RegisterRequestDTO request) {
+        AuthResponseDTO response = autnService.register(request);
+        return ResponseEntity.created(null).body(response);
+    }
+
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/dto/request/RegisterRequestDTO.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/dto/request/RegisterRequestDTO.java
@@ -1,0 +1,23 @@
+package com.universidad.proyecto.findtrack.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegisterRequestDTO {
+    
+    @NotBlank(message = "Nombre es requerido")
+    private String name;
+
+    @NotBlank(message = "Email es requerido")
+    @Email(message = "Email no es válido")
+    private String email;
+
+    @NotBlank(message = "Contraseña es requerida")
+    private String password;
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/dto/response/AuthResponseDTO.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/dto/response/AuthResponseDTO.java
@@ -1,0 +1,13 @@
+package com.universidad.proyecto.findtrack.dto.response;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthResponseDTO {
+
+    private String token;
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/exeptions/EmailAlreadyExistsException.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/exeptions/EmailAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.universidad.proyecto.findtrack.exeptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class EmailAlreadyExistsException extends RuntimeException {
+    public EmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/security/JwtUtil.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/security/JwtUtil.java
@@ -1,0 +1,26 @@
+package com.universidad.proyecto.findtrack.security;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtUtil {
+    
+    @Value("${jwt.secret}")
+    private String secret;
+
+    public String generateToken(UUID id) {
+        return Jwts.builder()
+                .setSubject(id.toString())
+                .setExpiration(new java.util.Date(System.currentTimeMillis() + (3600000*24))) 
+                .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+}

--- a/src/main/java/com/universidad/proyecto/FindTrack/service/AutnService.java
+++ b/src/main/java/com/universidad/proyecto/FindTrack/service/AutnService.java
@@ -1,0 +1,51 @@
+package com.universidad.proyecto.findtrack.service;
+
+import java.util.Optional;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.universidad.proyecto.findtrack.dto.response.AuthResponseDTO;
+import com.universidad.proyecto.findtrack.exeptions.EmailAlreadyExistsException;
+import com.universidad.proyecto.findtrack.dto.request.RegisterRequestDTO;
+
+import com.universidad.proyecto.findtrack.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import com.universidad.proyecto.findtrack.model.User;
+
+import com.universidad.proyecto.findtrack.security.JwtUtil;
+
+@Service
+@RequiredArgsConstructor
+public class AutnService {
+    
+    private final UserRepository userRepository;
+
+    
+    private final PasswordEncoder passwordEncoder;
+
+    private final JwtUtil jwtUtil;
+
+    
+
+
+    public AuthResponseDTO register(RegisterRequestDTO request) {
+        Optional<User> existingUser = userRepository.findByEmail(request.getEmail());
+        if (existingUser.isPresent()) {
+            throw new EmailAlreadyExistsException("Email ya registrado");
+        }
+        User user = new User();
+        user.setName(request.getName());
+        user.setEmail(request.getEmail());
+        user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+        userRepository.save(user);
+
+        String token = jwtUtil.generateToken(user.getId());
+        return new AuthResponseDTO(token);
+    }
+
+
+}


### PR DESCRIPTION
## Descripción
Se implementó el flujo completo para el **registro de usuarios**, abarcando:

- Recepción y validación de datos desde el cliente  
- Lógica de negocio para el registro  
- Persistencia en base de datos  
- Generación de respuesta al cliente (incluyendo token)  
- Exposición del endpoint correspondiente en el controlador  

**Issue relacionado:** #4  

---

## Que se hizo

- **`RegisterRequestDTO.java`**  
  Define el contrato de datos que recibe el API para el registro de usuario.

- **`AuthResponseDTO.java`**  
  Define la estructura de la respuesta del API (incluye token de autenticación).

- **`AuthService.java`**  
  Contiene la lógica de negocio para registrar usuarios en la base de datos.

- **`AuthController.java`**  
  Expone el endpoint para recibir y procesar solicitudes de registro.

- **`PasswordEncoderConfig.java`**  
  Configura el `PasswordEncoder` utilizando **BCrypt** para el cifrado de contraseñas.

- **`JwtUtil.java`**  
  Implementa la generación de tokens JWT.

- **`WebSecurityConfig.java`**  
  Configura la seguridad para permitir acceso sin autenticación a las rutas de `auth`.

- **`EmailAlreadyExistsException.java`**  
  Excepción personalizada para manejar intentos de registro con correos ya existentes.

---

## Cómo probarlo

1. Levantar el servidor  
2. Realizar una petición **POST** al endpoint de registro (ej. `/api/auth/register`) desde Postman  

###  Body de ejemplo
```json
{
  "name": "example",
  "email": "example@test.com",
  "password": "123456"
}

```
## Criterios de aceptacion
- [x] POST /api/auth/register con body válido devuelve 201 y el token
- [x] Los campos vacíos o email inválido devuelven 400 con mensaje de error
- [x] La contraseña se guarda hasheada con BCrypt (verificable en DB)
- [x] Si el email ya existe devuelve 409 Conflict con mensaje claro 
