### PR TITLE
feat(exceptions): implement global exception handler with standardized response

### DIFF
--- a/src/main/java/com/universidad/proyecto/findtrack/dto/response/ExceptionResponseDTO.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/dto/response/ExceptionResponseDTO.java
@@ -1,0 +1,33 @@
+package com.universidad.proyecto.findtrack.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExceptionResponseDTO {
+
+    private int status;
+
+    private String error;
+
+    private String message;
+
+    private Instant timestamp;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<FieldErrorDTO> errors;
+
+    public ExceptionResponseDTO(int status, String error, String message, Instant timestamp) {
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/dto/response/FieldErrorDTO.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/dto/response/FieldErrorDTO.java
@@ -1,0 +1,11 @@
+package com.universidad.proyecto.findtrack.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FieldErrorDTO {
+    private String field;
+    private String message;
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,90 @@
+package com.universidad.proyecto.findtrack.exceptions;
+
+import org.springframework.security.access.AccessDeniedException;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.universidad.proyecto.findtrack.dto.response.ExceptionResponseDTO;
+import com.universidad.proyecto.findtrack.dto.response.FieldErrorDTO;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(buildExceptionResponse(HttpStatus.NOT_FOUND, ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        List<FieldErrorDTO> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+            .map(error -> new FieldErrorDTO(error.getField(), error.getDefaultMessage()))
+            .toList();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(buildExceptionResponse(HttpStatus.BAD_REQUEST, "Datos de entrada inválidos", fieldErrors));
+    }
+    
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(buildExceptionResponse(HttpStatus.CONFLICT, "Violación de integridad de datos"));
+    }
+ 
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleAccessDeniedException(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(buildExceptionResponse(HttpStatus.FORBIDDEN, "Acceso denegado"));
+    }
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleEmailAlreadyExistsException(EmailAlreadyExistsException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(buildExceptionResponse(HttpStatus.CONFLICT, ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleInvalidCredentialsException(InvalidCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(buildExceptionResponse(HttpStatus.UNAUTHORIZED, ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleInvalidTokenException(InvalidTokenException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(buildExceptionResponse(HttpStatus.UNAUTHORIZED, ex.getMessage()));
+    }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleTokenExpiredException(TokenExpiredException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(buildExceptionResponse(HttpStatus.UNAUTHORIZED, ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponseDTO> handleGenericException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(buildExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Ocurrió un error inesperado"));
+    }
+
+
+
+    private ExceptionResponseDTO buildExceptionResponse(HttpStatus status, String message) {
+        return new ExceptionResponseDTO(
+            status.value(),
+            status.getReasonPhrase(),
+            message,
+            Instant.now()
+        );
+    }
+
+     private ExceptionResponseDTO buildExceptionResponse(HttpStatus status, String message, List<FieldErrorDTO> errors) {
+        return new ExceptionResponseDTO(
+            status.value(),
+            status.getReasonPhrase(),
+            message,
+            Instant.now(),
+            errors
+        );
+    }
+}
+
+

--- a/src/main/java/com/universidad/proyecto/findtrack/exceptions/InvalidCredentialsException.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/exceptions/InvalidCredentialsException.java
@@ -4,8 +4,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.http.HttpStatus;
 
 @ResponseStatus(HttpStatus.UNAUTHORIZED)
-public class InvalidCredentialsExeption extends RuntimeException {
-    public InvalidCredentialsExeption(String message) {
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String message) {
         super(message);
     }
     

--- a/src/main/java/com/universidad/proyecto/findtrack/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.universidad.proyecto.findtrack.exceptions;
+
+public class ResourceNotFoundException  extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+    
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/service/AuthService.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/service/AuthService.java
@@ -6,7 +6,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.universidad.proyecto.findtrack.dto.response.AuthResponseDTO;
 import com.universidad.proyecto.findtrack.exceptions.EmailAlreadyExistsException;
-import com.universidad.proyecto.findtrack.exceptions.InvalidCredentialsExeption;
+import com.universidad.proyecto.findtrack.exceptions.InvalidCredentialsException;
 import com.universidad.proyecto.findtrack.dto.request.LogInRequestDTO;
 import com.universidad.proyecto.findtrack.dto.request.RegisterRequestDTO;
 
@@ -51,9 +51,9 @@ public class AuthService {
 
     public AuthResponseDTO login(LogInRequestDTO request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new InvalidCredentialsExeption("Credenciales inválidas"));
+                .orElseThrow(() -> new InvalidCredentialsException("Credenciales inválidas"));
         if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
-            throw new InvalidCredentialsExeption("Credenciales inválidas");
+            throw new InvalidCredentialsException("Credenciales inválidas");
         }
         String token = jwtUtil.generateToken(user.getId());
         return new AuthResponseDTO(token);


### PR DESCRIPTION
## What this PR does

Implements a global exception handler that catches application exceptions and returns a standardized JSON response across the entire API. The handler covers `ResourceNotFoundException`, `MethodArgumentNotValidException`, `DataIntegrityViolationException`, `AccessDeniedException`, `EmailAlreadyExistsException`, `InvalidCredentialsException`, `InvalidTokenException`, `TokenExpiredException`, and a generic `Exception` fallback so that any unforeseen error also follows the standard format without leaking stacktraces.

## Related issue

Closes #7

## Changes

- `ExceptionResponseDTO.java`: standardized error response DTO with `status`, `error`, `message`, `timestamp`, and an optional `errors` list (omitted from JSON when null).
- `FieldErrorDTO.java`: structured representation of a single field validation error (`field` + `message`).
- `GlobalExceptionHandler.java`: `@RestControllerAdvice` class with handlers for all supported exceptions, returning the standardized response.
- `ResourceNotFoundException.java`: new exception for missing resources, returned as 404 by the handler.
- `InvalidCredentialsException.java`: renamed from `InvalidCredentialsExeption` (typo fix).
- `AuthService.java`: updated import to reflect the renamed exception.

## How to test

Run the application and try the following cases in Postman.

**Case 1 — validation errors (400):**
- `POST /api/auth/register` with body `{"email": "", "password": "", "name": ""}`
- Expected: status 400, response includes the `errors` array listing every invalid field.

**Case 2 — known business exception (409):**
- `POST /api/auth/register` with an email that is already registered.
- Expected: status 409, standardized JSON, `errors` field NOT present in the response.

**Case 3 — generic fallback (500):**
- Temporarily throw a `RuntimeException` from any controller method, hit the endpoint, then revert.
- Expected: status 500, message `"Ocurrió un error inesperado"`, no stacktrace, no internal exception message leaked.

## Acceptance criteria

- [x] All exceptions return the defined JSON format
- [x] The stacktrace never appears in the response
- [x] Validation errors list every invalid field