### PR TITLE
refactor(security): remove duplicate parsing in jwt

### DIFF
--- a/src/main/java/com/universidad/proyecto/findtrack/security/JwtAuthFilter.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/security/JwtAuthFilter.java
@@ -38,9 +38,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             if (authHeader != null && authHeader.startsWith("Bearer ")) {
                 String jwtToken = authHeader.substring(7);
 
-                jwtUtil.validateToken(jwtToken);
+                
 
-                UUID userId = jwtUtil.getUserIdFromToken(jwtToken);
+                UUID userId = jwtUtil.validateToken(jwtToken);
                 UserPrincipal userDetails = userDetailsService.loadUserByUsername(userId.toString());
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                         userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/universidad/proyecto/findtrack/security/JwtUtil.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/security/JwtUtil.java
@@ -8,7 +8,6 @@ import com.universidad.proyecto.findtrack.exceptions.TokenExpiredException;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.AuthenticationException;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -29,12 +28,15 @@ public class JwtUtil {
                 .compact();
     }
 
-    public void validateToken(String token) {
+    public UUID validateToken(String token) {
         try{
-            Jwts.parserBuilder()
+            String userId = Jwts.parserBuilder()
                 .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes()))
                 .build()
-                .parseClaimsJws(token);
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        return UUID.fromString(userId);
             
         } catch (ExpiredJwtException e) {
             throw new TokenExpiredException("Token expirado");
@@ -43,14 +45,6 @@ public class JwtUtil {
         }
     }
 
-    public UUID getUserIdFromToken(String token) {
-        String userId = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes()))
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
-        return UUID.fromString(userId);
-    }
+
 
 }


### PR DESCRIPTION
## Resumen

Se modifica `validateToken` para que devuelva el `UUID` del usuario contenido en 
el token. Con ello, `getUserIdFromToken` deja de ser necesario y se elimina el 
*code smell* del doble parseo del token en cada petición autenticada.

Closes #33

## Cambios realizados

- **`JwtUtil.java`**: `validateToken` ahora devuelve el `UUID` extraído del token 
  en lugar de `void`. Se elimina el método `getUserIdFromToken`.
- **`JwtAuthFilter.java`**: se sustituye la llamada a `getUserIdFromToken` por el 
  resultado de `validateToken`, eliminando el segundo parseo.

## Cómo probarlo

1. Arrancar la aplicación y comprobar que levanta sin errores.
2. `POST /auth/login` con credenciales válidas → debe devolver un JWT.
3. `GET /api/auth/me` con ese JWT en la cabecera `Authorization` → debe devolver `200`.
4. Repetir el paso 3 con un token inválido o manipulado → debe devolver `401`.

## Criterios de aceptación

- [x] `JwtAuthFilter` no contiene imports de `io.jsonwebtoken`.
- [x] El método `getUserIdFromToken` ya no existe en `JwtUtil`.
- [x] `validateToken` retorna `UUID` en lugar de `void`.