### PR TITLE
Feature/implement categories crud

### DIFF
--- a/src/main/java/com/universidad/proyecto/findtrack/controller/CategoryController.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/controller/CategoryController.java
@@ -1,0 +1,53 @@
+package com.universidad.proyecto.findtrack.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.universidad.proyecto.findtrack.security.UserPrincipal;
+import com.universidad.proyecto.findtrack.service.CategoryService;
+
+
+import jakarta.validation.Valid;
+
+import com.universidad.proyecto.findtrack.dto.request.CategoryRequestDTO;
+import com.universidad.proyecto.findtrack.dto.response.CategoryResponseDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponseDTO>> getUserCategories(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<CategoryResponseDTO> categories = categoryService.getUserCategories(userPrincipal.getId());
+        return ResponseEntity.ok(categories);
+    }
+
+    @PostMapping
+    public ResponseEntity<CategoryResponseDTO> createCategory(@AuthenticationPrincipal UserPrincipal userPrincipal, @RequestBody @Valid CategoryRequestDTO categoryRequest) {
+        CategoryResponseDTO createdCategory = categoryService.createCategory(categoryRequest, userPrincipal.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdCategory);
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<Void> deleteCategory(@AuthenticationPrincipal UserPrincipal userPrincipal, @PathVariable UUID categoryId) {
+        categoryService.deleteCategory(categoryId, userPrincipal.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/dto/request/CategoryRequestDTO.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/dto/request/CategoryRequestDTO.java
@@ -1,0 +1,21 @@
+package com.universidad.proyecto.findtrack.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryRequestDTO {
+
+    @NotBlank(message = "El nombre de la categoría es obligatorio")
+    private String name;
+
+    private String icon;
+
+    @Pattern(regexp = "^(INCOME|EXPENSE)$", message = "El tipo debe ser INCOME o EXPENSE")
+    private String type;
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/dto/response/CategoryResponseDTO.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/dto/response/CategoryResponseDTO.java
@@ -1,0 +1,19 @@
+package com.universidad.proyecto.findtrack.dto.response;
+
+import java.util.UUID;
+
+import com.universidad.proyecto.findtrack.model.CategoryType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryResponseDTO {
+    
+    private UUID id;
+    private String name;
+    private String icon;
+    private CategoryType type;
+    private boolean isDefault;
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/exceptions/CategoryInUseException.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/exceptions/CategoryInUseException.java
@@ -1,0 +1,11 @@
+package com.universidad.proyecto.findtrack.exceptions;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class CategoryInUseException extends RuntimeException {
+    public CategoryInUseException(String message) {
+        super(message);
+    }
+    
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/exceptions/GlobalExceptionHandler.java
@@ -34,6 +34,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponseDTO> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(buildExceptionResponse(HttpStatus.CONFLICT, "Violación de integridad de datos"));
     }
+
+    @ExceptionHandler(CategoryInUseException.class)
+    public ResponseEntity<ExceptionResponseDTO> handleCategoryInUseException(CategoryInUseException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(buildExceptionResponse(HttpStatus.CONFLICT, ex.getMessage()));
+    }
  
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ExceptionResponseDTO> handleAccessDeniedException(AccessDeniedException ex) {

--- a/src/main/java/com/universidad/proyecto/findtrack/model/Category.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/model/Category.java
@@ -32,7 +32,6 @@ public class Category {
 
     private String icon;
 
-    @Enumerated(EnumType.STRING)
     private CategoryType type;
 
     private boolean isDefault;

--- a/src/main/java/com/universidad/proyecto/findtrack/model/Category.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/model/Category.java
@@ -1,0 +1,37 @@
+package com.universidad.proyecto.findtrack.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private UUID userId;
+
+    private String name;
+
+    private String icon;
+
+    @Enumerated(EnumType.STRING)
+    private CategoryType type;
+
+    private boolean isDefault;
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/model/Category.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/model/Category.java
@@ -10,10 +10,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
 @Table(name = "categories")
 @Getter
 @AllArgsConstructor
@@ -34,4 +36,5 @@ public class Category {
     private CategoryType type;
 
     private boolean isDefault;
+
 }

--- a/src/main/java/com/universidad/proyecto/findtrack/model/CategoryType.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/model/CategoryType.java
@@ -1,0 +1,6 @@
+package com.universidad.proyecto.findtrack.model;
+
+public enum CategoryType {
+    INCOME,
+    EXPENSE
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/model/converter/CategoryTypeConverter.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/model/converter/CategoryTypeConverter.java
@@ -1,0 +1,29 @@
+package com.universidad.proyecto.findtrack.model.converter;
+import com.universidad.proyecto.findtrack.model.CategoryType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CategoryTypeConverter implements AttributeConverter<CategoryType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CategoryType categoryType) {
+        if (categoryType == null) {
+            return null;
+        }
+        return categoryType.name().toLowerCase();
+    }
+
+    @Override
+    public CategoryType convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        try {
+            return CategoryType.valueOf(dbData.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid value for CategoryType: " + dbData);
+        }
+    }
+    
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/repository/CategoryRepository.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/repository/CategoryRepository.java
@@ -2,9 +2,15 @@ package com.universidad.proyecto.findtrack.repository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import com.universidad.proyecto.findtrack.model.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
     
     List<Category> findByUserIdOrUserIdIsNull(UUID userId);
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM transactions WHERE category_id = :categoryId", nativeQuery = true)
+    boolean existsTransactionsByCategoryId(@Param("categoryId") UUID categoryId);
 }

--- a/src/main/java/com/universidad/proyecto/findtrack/repository/CategoryRepository.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.universidad.proyecto.findtrack.repository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.universidad.proyecto.findtrack.model.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+    
+    List<Category> findByUserIdOrUserIdIsNull(UUID userId);
+}

--- a/src/main/java/com/universidad/proyecto/findtrack/service/CategoryService.java
+++ b/src/main/java/com/universidad/proyecto/findtrack/service/CategoryService.java
@@ -1,0 +1,74 @@
+package com.universidad.proyecto.findtrack.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import com.universidad.proyecto.findtrack.dto.request.CategoryRequestDTO;
+import com.universidad.proyecto.findtrack.dto.response.CategoryResponseDTO;
+import com.universidad.proyecto.findtrack.exceptions.CategoryInUseException;
+import com.universidad.proyecto.findtrack.exceptions.ResourceNotFoundException;
+import com.universidad.proyecto.findtrack.model.Category;
+import com.universidad.proyecto.findtrack.model.CategoryType;
+import com.universidad.proyecto.findtrack.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryResponseDTO> getUserCategories(UUID userId) {
+
+        return categoryRepository.findByUserIdOrUserIdIsNull(userId).stream()
+                .map(category -> new CategoryResponseDTO(
+                        category.getId(),
+                        category.getName(),
+                        category.getIcon(),
+                        category.getType(),
+                        category.isDefault()))
+                .toList();
+    }
+
+    public CategoryResponseDTO createCategory(CategoryRequestDTO categoryRequest, UUID userId) {
+        Category category = Category.builder()
+                .userId(userId)
+                .name(categoryRequest.getName())
+                .icon(categoryRequest.getIcon())
+                .type(CategoryType.valueOf(categoryRequest.getType()))
+                .isDefault(false)
+                .build();
+
+        category = categoryRepository.save(category);
+
+        return new CategoryResponseDTO(
+                category.getId(),
+                category.getName(),
+                category.getIcon(),
+                category.getType(),
+                category.isDefault());
+    }
+
+    public void deleteCategory(UUID categoryId, UUID userId) {
+        Category category = categoryRepository.findById(categoryId)
+        .orElseThrow(() -> new ResourceNotFoundException("Categoría no encontrada"));
+
+        if(category.isDefault()) {
+            throw new AccessDeniedException("No se puede eliminar una categoría predeterminada");
+        }
+
+        if(!category.getUserId().equals(userId)) {
+            throw new AccessDeniedException("No se puede eliminar una categoría que no pertenece al usuario");
+        }
+
+        if(categoryRepository.existsTransactionsByCategoryId(categoryId)) {
+            throw new CategoryInUseException("No se puede eliminar la categoría porque está en uso por una transacción");
+        }
+        categoryRepository.delete(category);
+    }
+
+
+}


### PR DESCRIPTION
## Que hace este PR
Se implementó la lógica de negocio y los endpoints para crear, eliminar y obtener las categorías asociadas a un usuario autenticado. Además, se corrigió un bug en el parseo del `type` de la categoría hacia la base de datos: se eliminó la anotación `@Enumerated` y se reemplazó por un `AttributeConverter`.

## Issue relacionado
Closes #9

## Cambios realizados

### Controladores
- `CategoryController.java`: nueva clase con los endpoints `GET`, `POST` y `DELETE` sobre `/api/categories`.

### DTOs
- `CategoryRequestDTO.java`: contrato de entrada (request) para crear una categoría mediante `POST /api/categories`.
- `CategoryResponseDTO.java`: contrato de salida (response) que se devuelve al consumir `/api/categories`.

### Modelo y persistencia
- `Category.java`: entidad de categoría con los atributos `id`, `userId`, `name`, `icon`, `type` e `isDefault`.
- `CategoryType.java`: enum con los tipos de categoría.
- `CategoryTypeConverter.java`: `AttributeConverter` para persistir el `type` en la base de datos (reemplaza a `@Enumerated`).
- `CategoryRepository.java`: repositorio para consultar las categorías de un usuario y verificar cuáles tienen transacciones asociadas.

### Lógica de negocio
- `CategoryService.java`: métodos para obtener las categorías de un usuario, crear una categoría y eliminar una categoría aplicando sus restricciones.

### Manejo de errores
- `CategoryInUseException.java`: excepción para cuando no se puede eliminar una categoría porque tiene transacciones asociadas.
- `GlobalExceptionHandler.java`: se agregó el handler para `CategoryInUseException`.

## Cómo probarlo

### Flujo
1. Inicia sesión o regístrate con datos válidos para obtener un token.
2. Realiza un `POST` a `/api/categories` (autenticado) con el siguiente body:

```json
{
    "name": "Juegos",
    "icon": null,
    "type": "EXPENSE"
}
```
3. En Postman, realiza un `GET` a `/api/categories` enviando el token.
   - Debe devolver las categorías default más las del usuario autenticado.
   
4. Realiza un `DELETE` a `/api/categories/{categoryId}`.
   - El `categoryId` se obtiene del `GET`
   - Si el `categoryId` es válido y la categoría tiene `is_default = false`, se elimina correctamente.
   - Si el `categoryId` no existe, devuelve `404 Not Found`.
   - Si la categoría tiene `is_default = true`, no se permite eliminarla y devuelve `403 Forbidden` (access denied).
   - validado por revisión de código, pendiente de prueba end-to-end hasta que exista el módulo de transacciones
   - Si la categoría tiene transacciones asociadas, debe devolver `409 Conflict` — validado por revisión de código, pendiente de                prueba end-to-end hasta que exista el módulo de transacciones.

## Criterios de aceptación
- [x] `GET` devuelve las categorías default más las del usuario, sin mezclar las de otros usuarios.
- [x] No se puede eliminar una categoría con `is_default = true` (devuelve `403`).
- [x] No se puede eliminar una categoría que tenga transacciones asociadas (devuelve `409`) — validado por revisión de código, pendiente de prueba end-to-end hasta que exista el módulo de transacciones.